### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ x-airflow-common: &airflow-common
     - postgres
   networks:
     - code-with-yu
+  restart: always
 
 services:
   spark-master:


### PR DESCRIPTION
During docker-compose up --build airflow webserver exits and the process is tucked until it not killed and start again when airflow init done. Having `restart: always` will restart webserver building and building process will not be stopped